### PR TITLE
feat!: ctx abstracted to this library

### DIFF
--- a/dist/cjs/wallet.js
+++ b/dist/cjs/wallet.js
@@ -22,408 +22,6 @@ const EXTENDED_SEED_SIZE = DESCRIPTOR_SIZE + SEED_SIZE;
  * @todo re-check https://issues.chromium.org/issues/42212588
  * @module
  */
-const U32_MASK64$1 = /* @__PURE__ */ BigInt(2 ** 32 - 1);
-const _32n$1 = /* @__PURE__ */ BigInt(32);
-function fromBig$1(n, le = false) {
-    if (le)
-        return { h: Number(n & U32_MASK64$1), l: Number((n >> _32n$1) & U32_MASK64$1) };
-    return { h: Number((n >> _32n$1) & U32_MASK64$1) | 0, l: Number(n & U32_MASK64$1) | 0 };
-}
-function split$1(lst, le = false) {
-    const len = lst.length;
-    let Ah = new Uint32Array(len);
-    let Al = new Uint32Array(len);
-    for (let i = 0; i < len; i++) {
-        const { h, l } = fromBig$1(lst[i], le);
-        [Ah[i], Al[i]] = [h, l];
-    }
-    return [Ah, Al];
-}
-// Left rotate for Shift in [1, 32)
-const rotlSH$1 = (h, l, s) => (h << s) | (l >>> (32 - s));
-const rotlSL$1 = (h, l, s) => (l << s) | (h >>> (32 - s));
-// Left rotate for Shift in (32, 64), NOTE: 32 is special case.
-const rotlBH$1 = (h, l, s) => (l << (s - 32)) | (h >>> (64 - s));
-const rotlBL$1 = (h, l, s) => (h << (s - 32)) | (l >>> (64 - s));
-
-/**
- * Utilities for hex, bytes, CSPRNG.
- * @module
- */
-/*! noble-hashes - MIT License (c) 2022 Paul Miller (paulmillr.com) */
-/** Checks if something is Uint8Array. Be careful: nodejs Buffer will return true. */
-function isBytes$2(a) {
-    return a instanceof Uint8Array || (ArrayBuffer.isView(a) && a.constructor.name === 'Uint8Array');
-}
-/** Asserts something is positive integer. */
-function anumber$1(n, title = '') {
-    if (!Number.isSafeInteger(n) || n < 0) {
-        const prefix = title && `"${title}" `;
-        throw new Error(`${prefix}expected integer >= 0, got ${n}`);
-    }
-}
-/** Asserts something is Uint8Array. */
-function abytes$1(value, length, title = '') {
-    const bytes = isBytes$2(value);
-    const len = value?.length;
-    const needsLen = length !== undefined;
-    if (!bytes || (needsLen)) {
-        const prefix = title && `"${title}" `;
-        const ofLen = '';
-        const got = bytes ? `length=${len}` : `type=${typeof value}`;
-        throw new Error(prefix + 'expected Uint8Array' + ofLen + ', got ' + got);
-    }
-    return value;
-}
-/** Asserts a hash instance has not been destroyed / finished */
-function aexists$1(instance, checkFinished = true) {
-    if (instance.destroyed)
-        throw new Error('Hash instance has been destroyed');
-    if (checkFinished && instance.finished)
-        throw new Error('Hash#digest() has already been called');
-}
-/** Asserts output is properly-sized byte array */
-function aoutput$1(out, instance) {
-    abytes$1(out, undefined, 'digestInto() output');
-    const min = instance.outputLen;
-    if (out.length < min) {
-        throw new Error('"digestInto() output" expected to be of length >=' + min);
-    }
-}
-/** Cast u8 / u16 / u32 to u32. */
-function u32$1(arr) {
-    return new Uint32Array(arr.buffer, arr.byteOffset, Math.floor(arr.byteLength / 4));
-}
-/** Zeroize a byte array. Warning: JS provides no guarantees. */
-function clean$1(...arrays) {
-    for (let i = 0; i < arrays.length; i++) {
-        arrays[i].fill(0);
-    }
-}
-/** Create DataView of an array for easy byte-level manipulation. */
-function createView(arr) {
-    return new DataView(arr.buffer, arr.byteOffset, arr.byteLength);
-}
-/** The rotate right (circular right shift) operation for uint32 */
-function rotr(word, shift) {
-    return (word << (32 - shift)) | (word >>> shift);
-}
-/** Is current platform little-endian? Most are. Big-Endian platform: IBM */
-const isLE$1 = /* @__PURE__ */ (() => new Uint8Array(new Uint32Array([0x11223344]).buffer)[0] === 0x44)();
-/** The byte swap operation for uint32 */
-function byteSwap$1(word) {
-    return (((word << 24) & 0xff000000) |
-        ((word << 8) & 0xff0000) |
-        ((word >>> 8) & 0xff00) |
-        ((word >>> 24) & 0xff));
-}
-/** In place byte swap for Uint32Array */
-function byteSwap32$1(arr) {
-    for (let i = 0; i < arr.length; i++) {
-        arr[i] = byteSwap$1(arr[i]);
-    }
-    return arr;
-}
-const swap32IfBE$1 = isLE$1
-    ? (u) => u
-    : byteSwap32$1;
-// Built-in hex conversion https://caniuse.com/mdn-javascript_builtins_uint8array_fromhex
-const hasHexBuiltin$1 = /* @__PURE__ */ (() => 
-// @ts-ignore
-typeof Uint8Array.from([]).toHex === 'function' && typeof Uint8Array.fromHex === 'function')();
-// Array where index 0xf0 (240) is mapped to string 'f0'
-const hexes = /* @__PURE__ */ Array.from({ length: 256 }, (_, i) => i.toString(16).padStart(2, '0'));
-/**
- * Convert byte array to hex string. Uses built-in function, when available.
- * @example bytesToHex(Uint8Array.from([0xca, 0xfe, 0x01, 0x23])) // 'cafe0123'
- */
-function bytesToHex(bytes) {
-    abytes$1(bytes);
-    // @ts-ignore
-    if (hasHexBuiltin$1)
-        return bytes.toHex();
-    // pre-caching improves the speed 6x
-    let hex = '';
-    for (let i = 0; i < bytes.length; i++) {
-        hex += hexes[bytes[i]];
-    }
-    return hex;
-}
-// We use optimized technique to convert hex string to byte array
-const asciis$1 = { _0: 48, _9: 57, A: 65, F: 70, a: 97, f: 102 };
-function asciiToBase16$1(ch) {
-    if (ch >= asciis$1._0 && ch <= asciis$1._9)
-        return ch - asciis$1._0; // '2' => 50-48
-    if (ch >= asciis$1.A && ch <= asciis$1.F)
-        return ch - (asciis$1.A - 10); // 'B' => 66-(65-10)
-    if (ch >= asciis$1.a && ch <= asciis$1.f)
-        return ch - (asciis$1.a - 10); // 'b' => 98-(97-10)
-    return;
-}
-/**
- * Convert hex string to byte array. Uses built-in function, when available.
- * @example hexToBytes('cafe0123') // Uint8Array.from([0xca, 0xfe, 0x01, 0x23])
- */
-function hexToBytes$2(hex) {
-    if (typeof hex !== 'string')
-        throw new Error('hex string expected, got ' + typeof hex);
-    // @ts-ignore
-    if (hasHexBuiltin$1)
-        return Uint8Array.fromHex(hex);
-    const hl = hex.length;
-    const al = hl / 2;
-    if (hl % 2)
-        throw new Error('hex string expected, got unpadded hex of length ' + hl);
-    const array = new Uint8Array(al);
-    for (let ai = 0, hi = 0; ai < al; ai++, hi += 2) {
-        const n1 = asciiToBase16$1(hex.charCodeAt(hi));
-        const n2 = asciiToBase16$1(hex.charCodeAt(hi + 1));
-        if (n1 === undefined || n2 === undefined) {
-            const char = hex[hi] + hex[hi + 1];
-            throw new Error('hex string expected, got non-hex character "' + char + '" at index ' + hi);
-        }
-        array[ai] = n1 * 16 + n2; // multiply first octet, e.g. 'a3' => 10*16+3 => 160 + 3 => 163
-    }
-    return array;
-}
-/** Creates function with outputLen, blockLen, create properties from a class constructor. */
-function createHasher$1(hashCons, info = {}) {
-    const hashC = (msg, opts) => hashCons(opts).update(msg).digest();
-    const tmp = hashCons(undefined);
-    hashC.outputLen = tmp.outputLen;
-    hashC.blockLen = tmp.blockLen;
-    hashC.create = (opts) => hashCons(opts);
-    Object.assign(hashC, info);
-    return Object.freeze(hashC);
-}
-/** Creates OID opts for NIST hashes, with prefix 06 09 60 86 48 01 65 03 04 02. */
-const oidNist$1 = (suffix) => ({
-    oid: Uint8Array.from([0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, suffix]),
-});
-
-/**
- * SHA3 (keccak) hash function, based on a new "Sponge function" design.
- * Different from older hashes, the internal state is bigger than output size.
- *
- * Check out [FIPS-202](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf),
- * [Website](https://keccak.team/keccak.html),
- * [the differences between SHA-3 and Keccak](https://crypto.stackexchange.com/questions/15727/what-are-the-key-differences-between-the-draft-sha-3-standard-and-the-keccak-sub).
- *
- * Check out `sha3-addons` module for cSHAKE, k12, and others.
- * @module
- */
-// No __PURE__ annotations in sha3 header:
-// EVERYTHING is in fact used on every export.
-// Various per round constants calculations
-const _0n$1 = BigInt(0);
-const _1n$1 = BigInt(1);
-const _2n$1 = BigInt(2);
-const _7n$1 = BigInt(7);
-const _256n$1 = BigInt(256);
-const _0x71n$1 = BigInt(0x71);
-const SHA3_PI$1 = [];
-const SHA3_ROTL$1 = [];
-const _SHA3_IOTA$1 = []; // no pure annotation: var is always used
-for (let round = 0, R = _1n$1, x = 1, y = 0; round < 24; round++) {
-    // Pi
-    [x, y] = [y, (2 * x + 3 * y) % 5];
-    SHA3_PI$1.push(2 * (5 * y + x));
-    // Rotational
-    SHA3_ROTL$1.push((((round + 1) * (round + 2)) / 2) % 64);
-    // Iota
-    let t = _0n$1;
-    for (let j = 0; j < 7; j++) {
-        R = ((R << _1n$1) ^ ((R >> _7n$1) * _0x71n$1)) % _256n$1;
-        if (R & _2n$1)
-            t ^= _1n$1 << ((_1n$1 << BigInt(j)) - _1n$1);
-    }
-    _SHA3_IOTA$1.push(t);
-}
-const IOTAS$1 = split$1(_SHA3_IOTA$1, true);
-const SHA3_IOTA_H$1 = IOTAS$1[0];
-const SHA3_IOTA_L$1 = IOTAS$1[1];
-// Left rotation (without 0, 32, 64)
-const rotlH$1 = (h, l, s) => (s > 32 ? rotlBH$1(h, l, s) : rotlSH$1(h, l, s));
-const rotlL$1 = (h, l, s) => (s > 32 ? rotlBL$1(h, l, s) : rotlSL$1(h, l, s));
-/** `keccakf1600` internal function, additionally allows to adjust round count. */
-function keccakP$1(s, rounds = 24) {
-    const B = new Uint32Array(5 * 2);
-    // NOTE: all indices are x2 since we store state as u32 instead of u64 (bigints to slow in js)
-    for (let round = 24 - rounds; round < 24; round++) {
-        // Theta θ
-        for (let x = 0; x < 10; x++)
-            B[x] = s[x] ^ s[x + 10] ^ s[x + 20] ^ s[x + 30] ^ s[x + 40];
-        for (let x = 0; x < 10; x += 2) {
-            const idx1 = (x + 8) % 10;
-            const idx0 = (x + 2) % 10;
-            const B0 = B[idx0];
-            const B1 = B[idx0 + 1];
-            const Th = rotlH$1(B0, B1, 1) ^ B[idx1];
-            const Tl = rotlL$1(B0, B1, 1) ^ B[idx1 + 1];
-            for (let y = 0; y < 50; y += 10) {
-                s[x + y] ^= Th;
-                s[x + y + 1] ^= Tl;
-            }
-        }
-        // Rho (ρ) and Pi (π)
-        let curH = s[2];
-        let curL = s[3];
-        for (let t = 0; t < 24; t++) {
-            const shift = SHA3_ROTL$1[t];
-            const Th = rotlH$1(curH, curL, shift);
-            const Tl = rotlL$1(curH, curL, shift);
-            const PI = SHA3_PI$1[t];
-            curH = s[PI];
-            curL = s[PI + 1];
-            s[PI] = Th;
-            s[PI + 1] = Tl;
-        }
-        // Chi (χ)
-        for (let y = 0; y < 50; y += 10) {
-            for (let x = 0; x < 10; x++)
-                B[x] = s[y + x];
-            for (let x = 0; x < 10; x++)
-                s[y + x] ^= ~B[(x + 2) % 10] & B[(x + 4) % 10];
-        }
-        // Iota (ι)
-        s[0] ^= SHA3_IOTA_H$1[round];
-        s[1] ^= SHA3_IOTA_L$1[round];
-    }
-    clean$1(B);
-}
-/** Keccak sponge function. */
-let Keccak$1 = class Keccak {
-    state;
-    pos = 0;
-    posOut = 0;
-    finished = false;
-    state32;
-    destroyed = false;
-    blockLen;
-    suffix;
-    outputLen;
-    enableXOF = false;
-    rounds;
-    // NOTE: we accept arguments in bytes instead of bits here.
-    constructor(blockLen, suffix, outputLen, enableXOF = false, rounds = 24) {
-        this.blockLen = blockLen;
-        this.suffix = suffix;
-        this.outputLen = outputLen;
-        this.enableXOF = enableXOF;
-        this.rounds = rounds;
-        // Can be passed from user as dkLen
-        anumber$1(outputLen, 'outputLen');
-        // 1600 = 5x5 matrix of 64bit.  1600 bits === 200 bytes
-        // 0 < blockLen < 200
-        if (!(0 < blockLen && blockLen < 200))
-            throw new Error('only keccak-f1600 function is supported');
-        this.state = new Uint8Array(200);
-        this.state32 = u32$1(this.state);
-    }
-    clone() {
-        return this._cloneInto();
-    }
-    keccak() {
-        swap32IfBE$1(this.state32);
-        keccakP$1(this.state32, this.rounds);
-        swap32IfBE$1(this.state32);
-        this.posOut = 0;
-        this.pos = 0;
-    }
-    update(data) {
-        aexists$1(this);
-        abytes$1(data);
-        const { blockLen, state } = this;
-        const len = data.length;
-        for (let pos = 0; pos < len;) {
-            const take = Math.min(blockLen - this.pos, len - pos);
-            for (let i = 0; i < take; i++)
-                state[this.pos++] ^= data[pos++];
-            if (this.pos === blockLen)
-                this.keccak();
-        }
-        return this;
-    }
-    finish() {
-        if (this.finished)
-            return;
-        this.finished = true;
-        const { state, suffix, pos, blockLen } = this;
-        // Do the padding
-        state[pos] ^= suffix;
-        if ((suffix & 0x80) !== 0 && pos === blockLen - 1)
-            this.keccak();
-        state[blockLen - 1] ^= 0x80;
-        this.keccak();
-    }
-    writeInto(out) {
-        aexists$1(this, false);
-        abytes$1(out);
-        this.finish();
-        const bufferOut = this.state;
-        const { blockLen } = this;
-        for (let pos = 0, len = out.length; pos < len;) {
-            if (this.posOut >= blockLen)
-                this.keccak();
-            const take = Math.min(blockLen - this.posOut, len - pos);
-            out.set(bufferOut.subarray(this.posOut, this.posOut + take), pos);
-            this.posOut += take;
-            pos += take;
-        }
-        return out;
-    }
-    xofInto(out) {
-        // Sha3/Keccak usage with XOF is probably mistake, only SHAKE instances can do XOF
-        if (!this.enableXOF)
-            throw new Error('XOF is not possible for this instance');
-        return this.writeInto(out);
-    }
-    xof(bytes) {
-        anumber$1(bytes);
-        return this.xofInto(new Uint8Array(bytes));
-    }
-    digestInto(out) {
-        aoutput$1(out, this);
-        if (this.finished)
-            throw new Error('digest() was already called');
-        this.writeInto(out);
-        this.destroy();
-        return out;
-    }
-    digest() {
-        return this.digestInto(new Uint8Array(this.outputLen));
-    }
-    destroy() {
-        this.destroyed = true;
-        clean$1(this.state);
-    }
-    _cloneInto(to) {
-        const { blockLen, suffix, outputLen, rounds, enableXOF } = this;
-        to ||= new Keccak(blockLen, suffix, outputLen, enableXOF, rounds);
-        to.state32.set(this.state32);
-        to.pos = this.pos;
-        to.posOut = this.posOut;
-        to.finished = this.finished;
-        to.rounds = rounds;
-        // Suffix can change in cSHAKE
-        to.suffix = suffix;
-        to.outputLen = outputLen;
-        to.enableXOF = enableXOF;
-        to.destroyed = this.destroyed;
-        return to;
-    }
-};
-const genShake$1 = (suffix, blockLen, outputLen, info = {}) => createHasher$1((opts = {}) => new Keccak$1(blockLen, suffix, opts.dkLen === undefined ? outputLen : opts.dkLen, true), info);
-/** SHAKE256 XOF with 256-bit security. */
-const shake256$1 = 
-/* @__PURE__ */
-genShake$1(0x1f, 136, 32, /* @__PURE__ */ oidNist$1(0x0c));
-
-/**
- * Internal helpers for u64. BigUint64Array is too slow as per 2025, so we implement it using Uint32Array.
- * @todo re-check https://issues.chromium.org/issues/42212588
- * @module
- */
 const U32_MASK64 = /* @__PURE__ */ BigInt(2 ** 32 - 1);
 const _32n = /* @__PURE__ */ BigInt(32);
 function fromBig(n, le = false) {
@@ -502,6 +100,14 @@ function clean(...arrays) {
         arrays[i].fill(0);
     }
 }
+/** Create DataView of an array for easy byte-level manipulation. */
+function createView(arr) {
+    return new DataView(arr.buffer, arr.byteOffset, arr.byteLength);
+}
+/** The rotate right (circular right shift) operation for uint32 */
+function rotr(word, shift) {
+    return (word << (32 - shift)) | (word >>> shift);
+}
 /** Is current platform little-endian? Most are. Big-Endian platform: IBM */
 const isLE = /* @__PURE__ */ (() => new Uint8Array(new Uint32Array([0x11223344]).buffer)[0] === 0x44)();
 /** The byte swap operation for uint32 */
@@ -525,6 +131,24 @@ const swap32IfBE = isLE
 const hasHexBuiltin = /* @__PURE__ */ (() => 
 // @ts-ignore
 typeof Uint8Array.from([]).toHex === 'function' && typeof Uint8Array.fromHex === 'function')();
+// Array where index 0xf0 (240) is mapped to string 'f0'
+const hexes = /* @__PURE__ */ Array.from({ length: 256 }, (_, i) => i.toString(16).padStart(2, '0'));
+/**
+ * Convert byte array to hex string. Uses built-in function, when available.
+ * @example bytesToHex(Uint8Array.from([0xca, 0xfe, 0x01, 0x23])) // 'cafe0123'
+ */
+function bytesToHex(bytes) {
+    abytes(bytes);
+    // @ts-ignore
+    if (hasHexBuiltin)
+        return bytes.toHex();
+    // pre-caching improves the speed 6x
+    let hex = '';
+    for (let i = 0; i < bytes.length; i++) {
+        hex += hexes[bytes[i]];
+    }
+    return hex;
+}
 // We use optimized technique to convert hex string to byte array
 const asciis = { _0: 48, _9: 57, A: 65, F: 70, a: 97, f: 102 };
 function asciiToBase16(ch) {
@@ -2047,9 +1671,8 @@ function cryptoSignKeypair(passedSeed, pk, sk) {
  *
  * @example
  * const sig = new Uint8Array(CryptoBytes);
- * cryptoSignSignature(sig, message, sk, false);
- * // Or with custom context:
- * cryptoSignSignature(sig, message, sk, false, new Uint8Array([0x01, 0x02]));
+ * const ctx = new Uint8Array([0x01, 0x02]);
+ * cryptoSignSignature(sig, message, sk, false, ctx);
  */
 function cryptoSignSignature(sig, m, sk, randomizedSigning, ctx) {
   if (!sig || sig.length < CryptoBytes) {
@@ -2193,6 +1816,9 @@ function cryptoSignSignature(sig, m, sk, randomizedSigning, ctx) {
  * // signedMsg contains: signature (4627 bytes) || message
  */
 function cryptoSign(msg, sk, randomizedSigning, ctx) {
+  if (!(ctx instanceof Uint8Array)) {
+    throw new TypeError('ctx is required and must be a Uint8Array');
+  }
   const msgBytes = messageToBytes(msg);
 
   const sm = new Uint8Array(CryptoBytes + msgBytes.length);
@@ -2406,7 +2032,7 @@ function getAddressFromPKAndDescriptor(pk, descriptor) {
   const input = new Uint8Array(descBytes.length + pk.length);
   input.set(descBytes, 0);
   input.set(pk, descBytes.length);
-  return shake256$1.create({ dkLen: ADDRESS_SIZE }).update(input).digest();
+  return shake256.create({ dkLen: ADDRESS_SIZE }).update(input).digest();
 }
 
 /**
@@ -2446,8 +2072,8 @@ class HashMD {
         this.view = createView(this.buffer);
     }
     update(data) {
-        aexists$1(this);
-        abytes$1(data);
+        aexists(this);
+        abytes(data);
         const { view, buffer, blockLen } = this;
         const len = data.length;
         for (let pos = 0; pos < len;) {
@@ -2472,8 +2098,8 @@ class HashMD {
         return this;
     }
     digestInto(out) {
-        aexists$1(this);
-        aoutput$1(out, this);
+        aexists(this);
+        aoutput(out, this);
         this.finished = true;
         // Padding
         // We can avoid allocation of buffer for padding completely if it
@@ -2482,7 +2108,7 @@ class HashMD {
         let { pos } = this;
         // append the bit '1' to the message
         buffer[pos++] = 0b10000000;
-        clean$1(this.buffer.subarray(pos));
+        clean(this.buffer.subarray(pos));
         // we have less than padOffset left in buffer, so we cannot put length in
         // current block, need process it and pad again
         if (this.padOffset > blockLen - pos) {
@@ -2624,11 +2250,11 @@ class SHA2_32B extends HashMD {
         this.set(A, B, C, D, E, F, G, H);
     }
     roundClean() {
-        clean$1(SHA256_W);
+        clean(SHA256_W);
     }
     destroy() {
         this.set(0, 0, 0, 0, 0, 0, 0, 0);
-        clean$1(this.buffer);
+        clean(this.buffer);
     }
 }
 /** Internal SHA2-256 hash class. */
@@ -2655,8 +2281,8 @@ class _SHA256 extends SHA2_32B {
  * - Each sha256 hash is executing 2^18 bit operations.
  * - Good 2024 ASICs can do 200Th/sec with 3500 watts of power, corresponding to 2^36 hashes/joule.
  */
-const sha256 = /* @__PURE__ */ createHasher$1(() => new _SHA256(), 
-/* @__PURE__ */ oidNist$1(0x01));
+const sha256 = /* @__PURE__ */ createHasher(() => new _SHA256(), 
+/* @__PURE__ */ oidNist(0x01));
 
 /**
  * Shared byte/hex utils used across modules.
@@ -2705,7 +2331,7 @@ function toFixedU8(input, expectedLen, label = 'bytes') {
   if (isUint8(input)) {
     bytes = new Uint8Array(input);
   } else if (isHexLike(input)) {
-    bytes = hexToBytes$2(cleanHex(input));
+    bytes = hexToBytes$1(cleanHex(input));
   } else if (Array.isArray(input)) {
     bytes = Uint8Array.from(input);
   } else {
@@ -7220,6 +6846,7 @@ const DEFAULT_CTX = new Uint8Array([0x5a, 0x4f, 0x4e, 0x44]); // ZOND
  * SHA-256 hashing reduces the 48-byte seed to the required 32 bytes per spec.
  * This matches go-qrllib behavior for cross-implementation compatibility.
  *
+ * @param {Seed} seed - 48-byte QRL seed (hashed to 32 bytes internally)
  * @returns {{ pk: Uint8Array, sk: Uint8Array }}
  */
 function keygen(seed) {
@@ -7356,7 +6983,7 @@ class Wallet {
   }
 
   /**
-   * @param {string} mnemonicQR
+   * @param {string} mnemonic
    * @returns {Wallet}
    */
   static newWalletFromMnemonic(mnemonic) {

--- a/dist/mjs/wallet.js
+++ b/dist/mjs/wallet.js
@@ -4680,6 +4680,7 @@ const DEFAULT_CTX = new Uint8Array([0x5a, 0x4f, 0x4e, 0x44]); // ZOND
  * SHA-256 hashing reduces the 48-byte seed to the required 32 bytes per spec.
  * This matches go-qrllib behavior for cross-implementation compatibility.
  *
+ * @param {Seed} seed - 48-byte QRL seed (hashed to 32 bytes internally)
  * @returns {{ pk: Uint8Array, sk: Uint8Array }}
  */
 function keygen(seed) {
@@ -4816,7 +4817,7 @@ class Wallet {
   }
 
   /**
-   * @param {string} mnemonicQR
+   * @param {string} mnemonic
    * @returns {Wallet}
    */
   static newWalletFromMnemonic(mnemonic) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "2.0.1",
-        "@theqrl/mldsa87": "1.1.1"
+        "@theqrl/mldsa87": "2.0.0"
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
-      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1694,12 +1694,12 @@
       }
     },
     "node_modules/@theqrl/mldsa87": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-1.1.1.tgz",
-      "integrity": "sha512-nMrI7JkaPtIjmnqJ2xEtmW0rKlepOz2nn9NG6gWm3Bia85BQbedNf9czuo2+dP//0k0PNUirwhGRHTQzFNFK4g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.0.tgz",
+      "integrity": "sha512-j8+w9OPB9P4QzlOfVcJRN4TXZ3t522UwwBTU0H4+6f3tmNA/o4LoPseeaO7hWGZLd4mwUBIBTcz87wgGoSuOcw==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "^2.0.1"
+        "@noble/hashes": "2.0.1"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -1770,9 +1770,9 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
-      "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
+      "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3586,9 +3586,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4530,9 +4530,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -7606,9 +7606,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.0.0.tgz",
-      "integrity": "sha512-7rgWlxG2gAvFPIQfUreo1XYlNvrQ9VnQPFWdncPkdl3icucLK0InOxsaafbvxGTnI6Bk/Rxmslg0lQlRCuzOXw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.2.0.tgz",
+      "integrity": "sha512-KHnUjm68KSO/hqpWlVwagMDPrIjnDNY9r0DbKN79xEa5RU2MLUe0lICBGpWDF8cwmhUiN8r9A8DLGPVcFB62/A==",
       "dev": true,
       "funding": [
         {
@@ -8878,9 +8878,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.0.tgz",
-      "integrity": "sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@noble/hashes": "2.0.1",
-    "@theqrl/mldsa87": "1.1.1"
+    "@theqrl/mldsa87": "2.0.0"
   },
   "directories": {
     "lib": "src",

--- a/src/wallet/ml_dsa_87/crypto.js
+++ b/src/wallet/ml_dsa_87/crypto.js
@@ -21,6 +21,7 @@ const DEFAULT_CTX = new Uint8Array([0x5a, 0x4f, 0x4e, 0x44]); // ZOND
  * SHA-256 hashing reduces the 48-byte seed to the required 32 bytes per spec.
  * This matches go-qrllib behavior for cross-implementation compatibility.
  *
+ * @param {Seed} seed - 48-byte QRL seed (hashed to 32 bytes internally)
  * @returns {{ pk: Uint8Array, sk: Uint8Array }}
  */
 function keygen(seed) {

--- a/src/wallet/ml_dsa_87/wallet.js
+++ b/src/wallet/ml_dsa_87/wallet.js
@@ -65,7 +65,7 @@ class Wallet {
   }
 
   /**
-   * @param {string} mnemonicQR
+   * @param {string} mnemonic
    * @returns {Wallet}
    */
   static newWalletFromMnemonic(mnemonic) {


### PR DESCRIPTION
qrypto.js now throws on absent ctx instead of defaulting to ZOND. Responsibility of setting context is now with this library.

  1. src/wallet/ml_dsa_87/wallet.js:68 Reverted @param {string} mnemonicQR back to @param {string} mnemonic to match the actual function parameter.
  2. src/wallet/ml_dsa_87/crypto.js:25 Added missing @param {Seed} seed documentation to keygen().
  3. Version bump of @theqrl/mldsa87 to 2.0.0